### PR TITLE
Use explicit utf-8 encoding on searched path open.

### DIFF
--- a/lib/Domain/PublicSuffix.pm
+++ b/lib/Domain/PublicSuffix.pm
@@ -251,7 +251,7 @@ sub _parse_data_file {
 		foreach my $path (@paths) {
 			$path = File::Spec->catfile( $path, "effective_tld_names.dat" );
 			if ( -e $path ) {
-				open( $dat, '<', $path )
+				open( $dat, '<:encoding(UTF-8)', $path )
 					or die "Cannot open \'" . $path . "\': " . $!;
 				@tld_lines = <$dat>;
 				close($dat);


### PR DESCRIPTION
Hi Nicholas,

Trivial patch to add an explicit encoding to the second open in _parse_data_file. Tests were failing for me trying to install 0.14 without it.

Cheers,
Gavin
