### PR TITLE
Properly handle trailing dots

### DIFF
--- a/lib/Domain/PublicSuffix.pm
+++ b/lib/Domain/PublicSuffix.pm
@@ -215,7 +215,7 @@ sub get_root_domain {
 		$self->root_domain($suffix);
 	} else {
 		my $root_domain = $domain;
-		$root_domain =~ s/^.*\.(.*?\.$suffix)$/$1/;
+		$root_domain =~ s/^.*\.(.*?\.$suffix)\.?$/$1/;
 		$self->root_domain($root_domain);
 	}
 

--- a/t/08-issue-9.t
+++ b/t/08-issue-9.t
@@ -1,0 +1,17 @@
+#!/usr/bin/env perl
+use strict;
+use warnings;
+use Test::More;
+use Domain::PublicSuffix;
+
+ok( my $dps = Domain::PublicSuffix->new({
+	'use_default'        => 1,
+	'allow_unlisted_tld' => 0,
+}) );
+
+is( $dps->get_root_domain('www.example.com.'), 'example.com',
+    'Trailing dots do work.' );
+
+done_testing();
+
+1;


### PR DESCRIPTION
Trailing dots are valid in hostnames and even very common inside DNS
queries.

But without this patch `get_root_domain()` always returns the full
hostname instead of just the expected root domain.

This commit fixes #9 and adds a test case for that issue.